### PR TITLE
Check that client build id matches server

### DIFF
--- a/Source/AttoCommon/Public/AttoProtocol.h
+++ b/Source/AttoCommon/Public/AttoProtocol.h
@@ -8,10 +8,14 @@ struct ATTOCOMMON_API FAttoLoginRequest
 
 	FString Password;
 
+	// TODO: Handle this during WS upgrade procedure?
+	int32 BuildUniqueId = 0;
+
 	friend FArchive& operator<<(FArchive& Ar, FAttoLoginRequest& Message)
 	{
 		Ar << Message.Username;
 		Ar << Message.Password;
+		Ar << Message.BuildUniqueId;
 
 		return Ar;
 	}

--- a/Source/AttoServer/AttoServer.Build.cs
+++ b/Source/AttoServer/AttoServer.Build.cs
@@ -10,7 +10,8 @@ public class AttoServer : ModuleRules
 			"Core",
 			"CoreUObject",
 			"Engine",
-			"libWebSockets"
+			"libWebSockets",
+			"OnlineSubsystem"
 		});
 	}
 }

--- a/Source/AttoServer/Private/AttoConnection.cpp
+++ b/Source/AttoServer/Private/AttoConnection.cpp
@@ -122,6 +122,13 @@ void FAttoConnection::SendFromQueueInternal()
 
 FAttoLoginRequest::Result FAttoConnection::operator()(const FAttoLoginRequest& Message)
 {
+	if (Message.BuildUniqueId != GetBuildUniqueId())
+	{
+		return FAttoLoginRequest::Result{
+		    TInPlaceType<FString>(),
+		    FString::Printf(TEXT("Rejecting login [%s]: mismatched build id. Server: %d != Client: %d"), *Message.Username, GetBuildUniqueId(), Message.BuildUniqueId)};
+	}
+
 	if (Message.Username.IsEmpty())
 	{
 		return FAttoLoginRequest::Result{TInPlaceType<FString>(), TEXT("Username must not be empty")};

--- a/Source/OnlineSubsystemAtto/Private/OnlineIdentityAtto.cpp
+++ b/Source/OnlineSubsystemAtto/Private/OnlineIdentityAtto.cpp
@@ -54,7 +54,7 @@ bool FOnlineIdentityAtto::Login(const int32 LocalUserNum, const FOnlineAccountCr
 		    }
 
 		    Subsystem.AttoClient
-		        ->Send<FAttoLoginRequest>(AccountCredentials.Id, AccountCredentials.Token)
+		        ->Send<FAttoLoginRequest>(AccountCredentials.Id, AccountCredentials.Token, GetBuildUniqueId())
 		        .Next([=, this](auto&& LoginResult) {
 			        if (!LoginResult.IsOk())
 			        {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for including a unique build identifier in login requests.
  * Login attempts are now validated to ensure the client's build matches the server's build, with clear error messaging on mismatch.

* **Chores**
  * Updated internal dependencies to support online subsystem features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->