### PR TITLE
Add platform nickname to logs

### DIFF
--- a/Source/AttoCommon/Public/AttoProtocol.h
+++ b/Source/AttoCommon/Public/AttoProtocol.h
@@ -11,11 +11,14 @@ struct ATTOCOMMON_API FAttoLoginRequest
 	// TODO: Handle this during WS upgrade procedure?
 	int32 BuildUniqueId = 0;
 
+	TOptional<FString> PlatformNickname;
+
 	friend FArchive& operator<<(FArchive& Ar, FAttoLoginRequest& Message)
 	{
 		Ar << Message.Username;
 		Ar << Message.Password;
 		Ar << Message.BuildUniqueId;
+		Ar << Message.PlatformNickname;
 
 		return Ar;
 	}

--- a/Source/AttoServer/AttoServer.Build.cs
+++ b/Source/AttoServer/AttoServer.Build.cs
@@ -8,6 +8,7 @@ public class AttoServer : ModuleRules
 		{
 			"AttoCommon",
 			"Core",
+			"CoreOnline",
 			"CoreUObject",
 			"Engine",
 			"libWebSockets",

--- a/Source/AttoServer/Private/AttoConnection.cpp
+++ b/Source/AttoServer/Private/AttoConnection.cpp
@@ -118,7 +118,14 @@ void FAttoConnection::SendFromQueueInternal()
 
 TFuture<FAttoLoginRequest::Result> FAttoConnection::operator()(const FAttoLoginRequest& Message)
 {
-	UE_LOG(LogAtto, Verbose, TEXT("Login request from %s"), *Message.Username);
+	if (const auto* PlatformNicknamePtr = Message.PlatformNickname.GetPtrOrNull())
+	{
+		UE_LOG(LogAtto, Log, TEXT("Login request from %s [platform nickname: %s]"), *Message.Username, **PlatformNicknamePtr);
+	}
+	else
+	{
+		UE_LOG(LogAtto, Log, TEXT("Login request from %s"), *Message.Username);
+	}
 
 	auto Func = [&]() -> FAttoLoginRequest::Result {
 		if (Message.BuildUniqueId != GetBuildUniqueId())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Platform-aware login now includes your platform account nickname (when available) during sign-in.

- Improvements
  - Smoother login experience by integrating with your platform’s sign-in state.
  - Auto-login when you’re already signed in on the platform.
  - Clearer login messages by incorporating platform nickname context.

- Chores
  - Updated dependencies to support platform identity integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->